### PR TITLE
Final PR - Deprecate `zerobus-sdk-py` repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
+> **This repository has been moved to [databricks/zerobus-sdk](https://github.com/databricks/zerobus-sdk/tree/main/python).** This repo is archived and read-only. All new development, issues, and pull requests should go to the [monorepo](https://github.com/databricks/zerobus-sdk).
+>
+> | SDK | Link |
+> |-----|------|
+> | Rust | [databricks/zerobus-sdk/rust](https://github.com/databricks/zerobus-sdk/tree/main/rust) |
+> | TypeScript | [databricks/zerobus-sdk/typescript](https://github.com/databricks/zerobus-sdk/tree/main/typescript) |
+> | Java | [databricks/zerobus-sdk/java](https://github.com/databricks/zerobus-sdk/tree/main/java) |
+> | Python | [databricks/zerobus-sdk/python](https://github.com/databricks/zerobus-sdk/tree/main/python) |
+> | Go | [databricks/zerobus-sdk/go](https://github.com/databricks/zerobus-sdk/tree/main/go) |
+
 # Databricks Zerobus Ingest SDK for Python
 
-[![PyPI - Downloads](https://img.shields.io/pypi/dw/databricks-zerobus-ingest-sdk)](https://pypistats.org/packages/databricks-zerobus-ingest-sdk)
-[![PyPI - License](https://img.shields.io/pypi/l/databricks-zerobus-ingest-sdk)](https://github.com/databricks/zerobus-sdk-py/blob/main/LICENSE)
-![PyPI](https://img.shields.io/pypi/v/databricks-zerobus-ingest-sdk)
+[GA](https://docs.databricks.com/release-notes/release-types.html): This SDK is generally available and supported for production use cases. Minor and patch version updates will not contain breaking changes. Major version updates may include breaking changes.
 
-[Public Preview](https://docs.databricks.com/release-notes/release-types.html): This SDK is supported for production use cases and is available to all customers. Databricks is actively working on stabilizing the Zerobus Ingest SDK for Python. Minor version updates may include backwards-incompatible changes.
+We are keen to hear feedback from you on this SDK. Please [file issues](https://github.com/databricks/zerobus-sdk/issues), and we will address them.
 
-We are keen to hear feedback from you on this SDK. Please [file issues](https://github.com/databricks/zerobus-sdk-py/issues), and we will address them.
-
-The Databricks Zerobus Ingest SDK for Python provides a high-performance, Rust-backed client for ingesting data directly into Databricks Delta tables using the Zerobus streaming protocol. Built on top of the battle-tested [Rust SDK](https://github.com/databricks/zerobus-sdk-rs) using PyO3 bindings, it delivers native performance with a Python-friendly API. | See also the [SDK for Java](https://github.com/databricks/zerobus-sdk-java)
+The Databricks Zerobus Ingest SDK for Python provides a high-performance client for ingesting data directly into Databricks Delta tables using the Zerobus streaming protocol.
 
 ## Table of Contents
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The Python SDK and all of development for it has been transferred to the [monorepo (databricks/zerobus-sdk/python)](https://github.com/databricks/zerobus-sdk/tree/main/python).

## How is this tested?

N/A
